### PR TITLE
Trivial fixes

### DIFF
--- a/snappy_compress.cu
+++ b/snappy_compress.cu
@@ -694,7 +694,7 @@ snappy_status snappy_compress_host(struct host_buffer_context *input, struct hos
 
 	// Update output length
 	output->length = (output->curr - output->buffer);
-	printf("host output length = %ld\n",output->length);
+	free(table);
 
 	return SNAPPY_OK;
 }
@@ -785,6 +785,7 @@ snappy_status snappy_compress_cuda(struct host_buffer_context *input, struct hos
 	checkCudaErrors(cudaFree(output_offsets));
 	for(int i = 0; i < total_blocks; i++)
 		checkCudaErrors(cudaFree(table[i]));
+	checkCudaErrors(cudaFree(table));
 
 	return SNAPPY_OK;
 }

--- a/snappy_decompress.cu
+++ b/snappy_decompress.cu
@@ -465,7 +465,6 @@ snappy_status snappy_decompress_cuda(struct host_buffer_context *input, struct h
   	cudaGetDevice(&device);
 	cudaMemPrefetchAsync(input_currents,sizeof(uint8_t *) * total_blocks , device, NULL);
 	cudaMemPrefetchAsync(input_offsets,sizeof(uint32_t) * total_blocks , device, NULL);
-  	cudaMemPrefetchAsync(output->buffer, output->total_size, device, NULL);
 	cudaMemPrefetchAsync(input->buffer, input->total_size, device, NULL);
 
 


### PR DESCRIPTION
Greetings,

Here are a couple of changes that might be of interest to you. The first deals with a small memory leak of the hash table temporarily allocated in the compression path. The second saves data transfer time by not prefetching the output buffer prior to the call of the decompression kernel (that buffer should contain garbage, at most, and will have its contents overwritten by the kernel anyway).

Thanks!
Lucas